### PR TITLE
add png to plugin.xml as resource-file

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -68,6 +68,10 @@ under the License.
         <framework src="ImageIO.framework"/>
 
         <resource-file src="CDVSquareCameraDefaultPicture.jpg" />
+        <resource-file src="CDVSquareCamera-close-touched.png" />
+        <resource-file src="CDVSquareCamera-close.png" />
+        <resource-file src="CDVSquareCamera-take-touched.png" />
+        <resource-file src="CDVSquareCamera-take.png" />        
     </platform>
 
 


### PR DESCRIPTION
Thanks for the great plugin which solves our problem of making a square-only camera!
I found the buttons are missing and fixed it by adding them into plugin.xml
